### PR TITLE
Play-pause-functionality

### DIFF
--- a/content.js
+++ b/content.js
@@ -226,3 +226,35 @@ ttsButton.addEventListener("keydown", function (e) {
     onClickTtsButton();
   }
 });
+
+// Variable to track the playback state
+let isPlaying = false;
+
+// Function to update the playback state and toggle the button icon accordingly
+const setPlayingState = (playing) => {
+  isPlaying = playing;
+  ttsButton.src = chrome.runtime.getURL(playing ? "images/speak.svg" : "images/play.svg");
+};
+
+// Function to toggle playback when the button is clicked
+const togglePlayback = () => {
+  if (isPlaying) {
+    audioElement.pause();
+  } else {
+    audioElement.play();
+  }
+  setPlayingState(!isPlaying);
+};
+
+
+ttsButton.addEventListener("click", togglePlayback);
+
+audioElement.addEventListener("ended", () => {
+  setPlayingState(false);
+});
+
+audioElement.addEventListener("timeupdate", () => {
+  if (audioElement.paused) {
+    setPlayingState(false);
+  }
+});


### PR DESCRIPTION
**Description:**

The current code doesn't enable users a native way to pause audio once it has started. This can be annoying especially for long text. This enhancement introduces a streamlined solution to enable users with the ability to pause audio playback effortlessly. The implementation ensures a more user-friendly experience when consuming text-to-speech content.

**Summary of Changes:**

- Implemented a play/pause functionality for the text-to-speech button.
- Users can now pause audio playback during text-to-speech, enhancing control and convenience.
- This improvement aims to provide a smoother and more responsive interaction with the extension, particularly for managing longer passages of text.
