### PR TITLE
Add Refresh Button for Voice List

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -48,12 +48,12 @@ a:visited {
   padding: 20px;
 }
 
-.settingsItemNoPadding{
+.settingsItemNoPadding {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-left:20px;
-  padding-right:20px
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
 label {
@@ -110,4 +110,13 @@ button:hover {
 .shortcut {
   font-family: monospace;
   font-weight: bold;
+}
+
+.refresh-icon {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,25 @@
       <div class="settingsItem">
         <label for="voices">Voice:</label>
         <select id="voices"></select>
+        <button id="updateVoiceListButton" class="refresh-icon">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="lucide lucide-refresh-ccw"
+          >
+            <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
+            <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+            <path d="M16 16h5v5" />
+          </svg>
+        </button>
       </div>
       <div class="settingsItemNoPadding">
         <label for="mode">Model:</label>

--- a/popup.js
+++ b/popup.js
@@ -190,3 +190,16 @@ document.getElementById("clearStorage").addEventListener("click", function () {
     document.getElementById("apiKey").value = "";
   }
 });
+
+// Event listener to handle updating the voice list when the refresh button is clicked
+document
+  .getElementById("updateVoiceListButton")
+  .addEventListener("click", async () => {
+    try {
+      await fetchVoices();
+      alert("Voice list updated successfully.");
+    } catch (error) {
+      console.error("Error updating voice list:", error);
+      alert("Failed to update voice list. Please check your API key.");
+    }
+  });


### PR DESCRIPTION
While using this extension I noticed there was no way to update the voice list if you had recently added or removed a voice. I have implemented a very simple refresh button to support this.


Enhancements to user interface:

* [`popup.css`](diffhunk://#diff-dd634a4ce8d690293e4e00c2067c5591de95a6dca78e5d94a388fbbe6201dd5bR114-R122): Added `.refresh-icon` class to style the refresh button with specific dimensions and alignment properties.
* [`popup.html`](diffhunk://#diff-28d0d8f0960f87f8d291caace058de871b8145e54d727271b564eba832123ec8R23-R41): Introduced a new button with an SVG icon for updating the voice list, placed next to the voice selection dropdown.

Functional improvements:

* [`popup.js`](diffhunk://#diff-3df6958c77d615b266b54fcf12fadf313e7c1e4b168f0c61ea8c3424eb39eb8cR193-R205): Added an event listener for the new refresh button to fetch and update the voice list when clicked, with error handling and user feedback.

Minor style correction:

* [`popup.css`](diffhunk://#diff-dd634a4ce8d690293e4e00c2067c5591de95a6dca78e5d94a388fbbe6201dd5bL56-R56): Fixed inconsistent spacing in the `padding-right` property of the `a:visited` selector.

Here is an image of the new button.
<img width="434" alt="new button" src="https://github.com/user-attachments/assets/8a8e7a92-14b7-441e-822e-7400feb999cd">
