### PR TITLE
Add OpenAI TTS support, fix Manifest V3 compatibility, make CSP-safe too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 .env
 .env.test
 media/.DS_Store
+*.ipynb

--- a/README_updates.md
+++ b/README_updates.md
@@ -1,0 +1,81 @@
+## Installation and Usage of update_extension.py:
+
+### 1. **Install required packages:**
+```bash
+pip install requests
+```
+
+### 2. **Save the script:**
+Save it as `update_extension.py` in your extension directory.
+
+### 3. **Run the script:**
+
+**Option A: Interactive mode:**
+```bash
+python update_extension.py
+```
+
+**Option B: Command line mode:**
+```bash
+python update_extension.py --api-key "your-api-key-here" --path "./extension-folder"
+```
+
+**Option C: Create a batch file (Windows):**
+```batch
+@echo off
+echo Updating ElevenLabs Extension...
+python update_extension.py --api-key "YOUR_API_KEY" --path "C:\path\to\extension"
+pause
+```
+
+**Option D: Create a shell script (Linux/Mac):**
+```bash
+#!/bin/bash
+echo "Updating ElevenLabs Extension..."
+python3 update_extension.py --api-key "YOUR_API_KEY" --path "/path/to/extension"
+read -p "Press enter to continue"
+```
+
+### 4. **What the script does:**
+
+1. **Fetches current data:**
+   - Available TTS models from ElevenLabs
+   - Available voices
+   - Your subscription info
+
+2. **Updates extension files:**
+   - `popup.html`: Updates the model dropdown with current options
+   - `content.js`: Updates the model mapping logic
+   - Creates `models.json` and `voices.json` for reference
+   - Updates `manifest.json` version (optional)
+   - Creates `update_report.txt` with details
+
+3. **Creates backup files** (optional feature you can add):
+   - Backs up original files before modifying
+
+### 5. **Security considerations:**
+
+1. **API Key Storage:** The script doesn't store your API key permanently
+2. **Backup:** Consider adding backup functionality
+3. **Validation:** The script validates API responses
+
+### 6. **Schedule automatic updates (optional):**
+
+**Windows Task Scheduler:**
+- Create a task to run weekly
+- Use the batch file
+
+**Linux/Mac cron job:**
+```bash
+# Run every Sunday at 2 AM
+0 2 * * 0 /path/to/update_script.sh
+```
+
+### 7. **Manual verification after update:**
+Always check:
+1. The extension loads without errors
+2. All models appear in the dropdown
+3. TTS works with different models
+4. Check the update report for any issues
+
+This script gives you a maintainable way to keep your extension current with ElevenLabs' latest offerings without needing to manually edit code each time they add new models.

--- a/background.js
+++ b/background.js
@@ -1,8 +1,9 @@
-
-chrome.contextMenus.create({
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
     "id": "readOutLoud",
     "title": "Human Reader - Start reading",
     "contexts": ["selection"],
+  });
 });
 
 // Could be adde in future

--- a/background.js
+++ b/background.js
@@ -19,7 +19,8 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
 
 // Send message to content.js file
 async function transmitSignal() {
-    const result = await chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-        chrome.tabs.sendMessage(tabs[0].id, {action: "readOutLoud"}, function(response) {});  
-    });
-  }
+    const tabs = await chrome.tabs.query({active: true, currentWindow: true});
+    if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, {action: "readOutLoud"});
+    }
+}

--- a/content.js
+++ b/content.js
@@ -82,8 +82,15 @@ const fetchElevenLabsResponse = async (storage) => {
   const mode = storage.mode || "eleven_turbo_v2_5";
   
   // Normalize model_id
-  const model_id = 
-    mode.includes("v3") ? "eleven_v3" :
+    const model_id =
+    (mode === "eleven_v3_(alpha)" || mode === "eleven_v3") ? "eleven_v3" :
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
+    "eleven_monolingual_v1"; // default
     mode.includes("multilingual_v2") ? "eleven_multilingual_v2" :
     mode.includes("flash_v2_5") || mode.includes("flash_v2.5") ? "eleven_flash_v2_5" :
     mode.includes("turbo_v2_5") || mode.includes("turbo_v2.5") ? "eleven_turbo_v2_5" :

--- a/content.js
+++ b/content.js
@@ -49,8 +49,50 @@ const fetchResponse = async () => {
     ? storage.selectedVoiceId
     : "21m00Tcm4TlvDq8ikWAM"; //fallback Voice ID
   const mode = storage.mode
-  const model_id =
-    (mode === "englishfast" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+              const model_id =
+    (mode === "eleven_v3_(alpha)" || mode === "eleven_v3") ? "eleven_v3" :
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
+    "eleven_multilingual_v1"; // default
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
+    "eleven_monolingual_v1"; // default
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
+    "eleven_multilingual_v1"; // default
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
+    "eleven_monolingual_v1"; // default
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
+    "eleven_monolingual_v1"; // default
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
+    "eleven_multilingual_v1"; // default
       (mode === "multilingual" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
         "eleven_turbo_v2_5";
 

--- a/content.js
+++ b/content.js
@@ -44,57 +44,54 @@ const readStorage = async (keys) => {
 };
 
 const fetchResponse = async () => {
-  const storage = await readStorage(["apiKey", "selectedVoiceId", "mode"]);
-  const selectedVoiceId = storage.selectedVoiceId
-    ? storage.selectedVoiceId
-    : "21m00Tcm4TlvDq8ikWAM"; //fallback Voice ID
-  const mode = storage.mode
-              const model_id =
-    (mode === "eleven_v3_(alpha)" || mode === "eleven_v3") ? "eleven_v3" :
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
-    "eleven_multilingual_v1"; // default
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
-    "eleven_monolingual_v1"; // default
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
-    "eleven_multilingual_v1"; // default
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
-    "eleven_monolingual_v1"; // default
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_multilingual_v1" || mode === "eleven_multilingual_v1") ? "eleven_multilingual_v1" :
-    "eleven_monolingual_v1"; // default
-    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
-    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
-    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
-    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
-    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
-    "eleven_multilingual_v1"; // default
-      (mode === "multilingual" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
-        "eleven_turbo_v2_5";
+  const storage = await readStorage([
+    "apiKey", "selectedVoiceId", "mode", "provider", 
+    "openaiApiKey", "openaiVoice", "openaiModel"
+  ]);
+  const provider = storage.provider || "elevenlabs";
+
+  if (provider === "openai") {
+    return fetchOpenAIResponse(storage);
+  } else {
+    return fetchElevenLabsResponse(storage);
+  }
+};
+
+const fetchOpenAIResponse = async (storage) => {
+  const voice = storage.openaiVoice || "alloy";
+  const model = storage.openaiModel || "gpt-4o-mini-tts";
+  
+  const response = await fetch("https://api.openai.com/v1/audio/speech", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${storage.openaiApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: model,
+      input: textToPlay,
+      voice: voice,
+      response_format: "mp3",
+    }),
+  });
+  return response;
+};
+
+const fetchElevenLabsResponse = async (storage) => {
+  const selectedVoiceId = storage.selectedVoiceId || "21m00Tcm4TlvDq8ikWAM";
+  const mode = storage.mode || "eleven_turbo_v2_5";
+  
+  // Normalize model_id
+  const model_id = 
+    mode.includes("v3") ? "eleven_v3" :
+    mode.includes("multilingual_v2") ? "eleven_multilingual_v2" :
+    mode.includes("flash_v2_5") || mode.includes("flash_v2.5") ? "eleven_flash_v2_5" :
+    mode.includes("turbo_v2_5") || mode.includes("turbo_v2.5") ? "eleven_turbo_v2_5" :
+    mode.includes("turbo_v2") ? "eleven_turbo_v2" :
+    mode.includes("flash_v2") ? "eleven_flash_v2" :
+    mode.includes("monolingual") || mode.includes("english_v1") ? "eleven_monolingual_v1" :
+    mode.includes("multilingual_v1") ? "eleven_multilingual_v1" :
+    "eleven_turbo_v2_5";
 
   const response = await fetch(
     `https://api.elevenlabs.io/v1/text-to-speech/${selectedVoiceId}/stream`,
@@ -118,16 +115,20 @@ const fetchResponse = async () => {
   return response;
 };
 
-const handleMissingApiKey = () => {
+
+const handleMissingApiKey = async () => {
+  const storage = await readStorage(["provider"]);
+  const provider = storage.provider || "elevenlabs";
+  const providerName = provider === "openai" ? "OpenAI" : "ElevenLabs";
+  
   setButtonState("speak");
   const audio = new Audio(chrome.runtime.getURL("media/error-no-api-key.mp3"));
   audio.play();
   //since alert() is blocking, timeout is needed so audio plays while alert is visible.
   setTimeout(() => {
     alert(
-      "Please set your Elevenlabs API key in the extension settings to use Human Reader."
+      `Please set your ${providerName} API key in the extension settings to use Human Reader.`
     );
-    chrome.storage.local.clear();
     setButtonState("play");
   }, 100);
 };
@@ -153,8 +154,11 @@ const stopAudio = () => {
 
 let sourceOpenEventAdded = false;
 const streamAudio = async () => {
-  const storage = await readStorage(["apiKey", "speed"]);
-  if (!storage.apiKey) {
+  const storage = await readStorage(["apiKey", "speed", "provider", "openaiApiKey"]);
+  const provider = storage.provider || "elevenlabs";
+  const hasApiKey = provider === "openai" ? storage.openaiApiKey : storage.apiKey;
+  
+  if (!hasApiKey) {
     handleMissingApiKey();
     return;
   }

--- a/content.js
+++ b/content.js
@@ -82,8 +82,15 @@ const fetchElevenLabsResponse = async (storage) => {
   const mode = storage.mode || "eleven_turbo_v2_5";
   
   // Normalize model_id
-    const model_id =
+      const model_id =
     (mode === "eleven_v3_(alpha)" || mode === "eleven_v3") ? "eleven_v3" :
+    (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
+    (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
+    (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :
+    (mode === "eleven_turbo_v2" || mode === "eleven_turbo_v2") ? "eleven_turbo_v2" :
+    (mode === "eleven_flash_v2" || mode === "eleven_flash_v2") ? "eleven_flash_v2" :
+    (mode === "eleven_english_v1" || mode === "eleven_monolingual_v1") ? "eleven_monolingual_v1" :
+    "eleven_multilingual_v1"; // default
     (mode === "eleven_multilingual_v2" || mode === "eleven_multilingual_v2") ? "eleven_multilingual_v2" :
     (mode === "eleven_flash_v2.5" || mode === "eleven_flash_v2_5") ? "eleven_flash_v2_5" :
     (mode === "eleven_turbo_v2.5" || mode === "eleven_turbo_v2_5") ? "eleven_turbo_v2_5" :

--- a/content.js
+++ b/content.js
@@ -337,7 +337,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "readOutLoud") {
     onClickTtsButton();
   }
-  return true
 });
 
 document.addEventListener("keydown", function (e) {

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,6 @@
   "permissions": ["storage", "contextMenus"],
 
   "background": {
-    "service_worker": "background.js",
-    "persistent": false
+    "service_worker": "background.js"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Human Reader",
-  "version": "1.7",
-  "description": "Listen to any text in the web in a human voice. A simple extension powered by ElevenLabs to convert any text to speech.",
+  "version": "1.8",
+  "description": "Listen to any text in the web in a human voice. Uses your ElevenLabs or OpenAI API access to convert any text to speech.",
   "icons": {
     "16": "images/icon16.png",
     "48": "images/icon48.png",
@@ -23,7 +23,10 @@
       "css": ["style.css"]
     }
   ],
-  "host_permissions": ["<all_urls>", "https://api.openai.com/*"],
+  "host_permissions": [
+     "https://api.elevenlabs.io/*",
+     "https://api.openai.com/*"
+  ],
   "web_accessible_resources": [
     {
       "resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "permissions": ["storage", "contextMenus"],
+  "permissions": ["storage", "contextMenus", "offscreen"],
 
   "background": {
     "service_worker": "background.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Human Reader, powered by ElevenLabs",
+  "name": "Human Reader",
   "version": "1.7",
   "description": "Listen to any text in the web in a human voice. A simple extension powered by ElevenLabs to convert any text to speech.",
   "icons": {
@@ -23,7 +23,7 @@
       "css": ["style.css"]
     }
   ],
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": ["<all_urls>", "https://api.openai.com/*"],
   "web_accessible_resources": [
     {
       "resources": [

--- a/models.json
+++ b/models.json
@@ -742,21 +742,6 @@
     "can_do_voice_conversion": false
   },
   {
-    "model_id": "eleven_monolingual_v1",
-    "name": "Eleven English v1",
-    "description": "Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
-    "can_be_finetuned": false,
-    "token_cost_factor": 1.0,
-    "languages": [
-      {
-        "language_id": "en",
-        "name": "English"
-      }
-    ],
-    "can_do_text_to_speech": true,
-    "can_do_voice_conversion": false
-  },
-  {
     "model_id": "eleven_multilingual_v1",
     "name": "Eleven Multilingual v1",
     "description": "Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
@@ -798,6 +783,21 @@
       {
         "language_id": "ar",
         "name": "Arabic"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_monolingual_v1",
+    "name": "Eleven English v1",
+    "description": "Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
+    "can_be_finetuned": false,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
       }
     ],
     "can_do_text_to_speech": true,

--- a/models.json
+++ b/models.json
@@ -1,0 +1,806 @@
+[
+  {
+    "model_id": "eleven_v3",
+    "name": "Eleven v3 (alpha)",
+    "description": "The most expressive model. Supports 70+ languages. Requires more prompt engineering than our previous models. In alpha and the reliability will improve over time.",
+    "can_be_finetuned": false,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "af",
+        "name": "Afrikaans"
+      },
+      {
+        "language_id": "ar",
+        "name": "Arabic"
+      },
+      {
+        "language_id": "hy",
+        "name": "Armenian"
+      },
+      {
+        "language_id": "as",
+        "name": "Assamese"
+      },
+      {
+        "language_id": "az",
+        "name": "Azerbaijani"
+      },
+      {
+        "language_id": "be",
+        "name": "Belarusian"
+      },
+      {
+        "language_id": "bn",
+        "name": "Bengali"
+      },
+      {
+        "language_id": "bs",
+        "name": "Bosnian"
+      },
+      {
+        "language_id": "bg",
+        "name": "Bulgarian"
+      },
+      {
+        "language_id": "ca",
+        "name": "Catalan"
+      },
+      {
+        "language_id": "ceb",
+        "name": "Cebuano"
+      },
+      {
+        "language_id": "ny",
+        "name": "Chichewa"
+      },
+      {
+        "language_id": "hr",
+        "name": "Croatian"
+      },
+      {
+        "language_id": "cs",
+        "name": "Czech"
+      },
+      {
+        "language_id": "da",
+        "name": "Danish"
+      },
+      {
+        "language_id": "nl",
+        "name": "Dutch"
+      },
+      {
+        "language_id": "en",
+        "name": "English"
+      },
+      {
+        "language_id": "et",
+        "name": "Estonian"
+      },
+      {
+        "language_id": "fil",
+        "name": "Filipino"
+      },
+      {
+        "language_id": "fi",
+        "name": "Finnish"
+      },
+      {
+        "language_id": "fr",
+        "name": "French"
+      },
+      {
+        "language_id": "gl",
+        "name": "Galician"
+      },
+      {
+        "language_id": "ka",
+        "name": "Georgian"
+      },
+      {
+        "language_id": "de",
+        "name": "German"
+      },
+      {
+        "language_id": "el",
+        "name": "Greek"
+      },
+      {
+        "language_id": "gu",
+        "name": "Gujarati"
+      },
+      {
+        "language_id": "ha",
+        "name": "Hausa"
+      },
+      {
+        "language_id": "he",
+        "name": "Hebrew"
+      },
+      {
+        "language_id": "hi",
+        "name": "Hindi"
+      },
+      {
+        "language_id": "hu",
+        "name": "Hungarian"
+      },
+      {
+        "language_id": "is",
+        "name": "Icelandic"
+      },
+      {
+        "language_id": "id",
+        "name": "Indonesian"
+      },
+      {
+        "language_id": "ga",
+        "name": "Irish"
+      },
+      {
+        "language_id": "it",
+        "name": "Italian"
+      },
+      {
+        "language_id": "ja",
+        "name": "Japanese"
+      },
+      {
+        "language_id": "jv",
+        "name": "Javanese"
+      },
+      {
+        "language_id": "kn",
+        "name": "Kannada"
+      },
+      {
+        "language_id": "kk",
+        "name": "Kazakh"
+      },
+      {
+        "language_id": "ky",
+        "name": "Kirghiz"
+      },
+      {
+        "language_id": "ko",
+        "name": "Korean"
+      },
+      {
+        "language_id": "lv",
+        "name": "Latvian"
+      },
+      {
+        "language_id": "ln",
+        "name": "Lingala"
+      },
+      {
+        "language_id": "lt",
+        "name": "Lithuanian"
+      },
+      {
+        "language_id": "lb",
+        "name": "Luxembourgish"
+      },
+      {
+        "language_id": "mk",
+        "name": "Macedonian"
+      },
+      {
+        "language_id": "ms",
+        "name": "Malay"
+      },
+      {
+        "language_id": "ml",
+        "name": "Malayalam"
+      },
+      {
+        "language_id": "zh",
+        "name": "Mandarin Chinese"
+      },
+      {
+        "language_id": "mr",
+        "name": "Marathi"
+      },
+      {
+        "language_id": "ne",
+        "name": "Nepali"
+      },
+      {
+        "language_id": "no",
+        "name": "Norwegian"
+      },
+      {
+        "language_id": "ps",
+        "name": "Pashto"
+      },
+      {
+        "language_id": "fa",
+        "name": "Persian"
+      },
+      {
+        "language_id": "pl",
+        "name": "Polish"
+      },
+      {
+        "language_id": "pt",
+        "name": "Portuguese"
+      },
+      {
+        "language_id": "pa",
+        "name": "Punjabi"
+      },
+      {
+        "language_id": "ro",
+        "name": "Romanian"
+      },
+      {
+        "language_id": "ru",
+        "name": "Russian"
+      },
+      {
+        "language_id": "sr",
+        "name": "Serbian"
+      },
+      {
+        "language_id": "sd",
+        "name": "Sindhi"
+      },
+      {
+        "language_id": "sk",
+        "name": "Slovak"
+      },
+      {
+        "language_id": "sl",
+        "name": "Slovenian"
+      },
+      {
+        "language_id": "so",
+        "name": "Somali"
+      },
+      {
+        "language_id": "es",
+        "name": "Spanish"
+      },
+      {
+        "language_id": "sw",
+        "name": "Swahili"
+      },
+      {
+        "language_id": "sv",
+        "name": "Swedish"
+      },
+      {
+        "language_id": "ta",
+        "name": "Tamil"
+      },
+      {
+        "language_id": "te",
+        "name": "Telugu"
+      },
+      {
+        "language_id": "th",
+        "name": "Thai"
+      },
+      {
+        "language_id": "tr",
+        "name": "Turkish"
+      },
+      {
+        "language_id": "uk",
+        "name": "Ukrainian"
+      },
+      {
+        "language_id": "ur",
+        "name": "Urdu"
+      },
+      {
+        "language_id": "vi",
+        "name": "Vietnamese"
+      },
+      {
+        "language_id": "cy",
+        "name": "Welsh"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_multilingual_v2",
+    "name": "Eleven Multilingual v2",
+    "description": "Our most life-like, emotionally rich mode in 29 languages. Best for voice overs, audiobooks, post-production, or any other content creation needs.",
+    "can_be_finetuned": true,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      },
+      {
+        "language_id": "ja",
+        "name": "Japanese"
+      },
+      {
+        "language_id": "zh",
+        "name": "Chinese"
+      },
+      {
+        "language_id": "de",
+        "name": "German"
+      },
+      {
+        "language_id": "hi",
+        "name": "Hindi"
+      },
+      {
+        "language_id": "fr",
+        "name": "French"
+      },
+      {
+        "language_id": "ko",
+        "name": "Korean"
+      },
+      {
+        "language_id": "pt",
+        "name": "Portuguese"
+      },
+      {
+        "language_id": "it",
+        "name": "Italian"
+      },
+      {
+        "language_id": "es",
+        "name": "Spanish"
+      },
+      {
+        "language_id": "id",
+        "name": "Indonesian"
+      },
+      {
+        "language_id": "nl",
+        "name": "Dutch"
+      },
+      {
+        "language_id": "tr",
+        "name": "Turkish"
+      },
+      {
+        "language_id": "fil",
+        "name": "Filipino"
+      },
+      {
+        "language_id": "pl",
+        "name": "Polish"
+      },
+      {
+        "language_id": "sv",
+        "name": "Swedish"
+      },
+      {
+        "language_id": "bg",
+        "name": "Bulgarian"
+      },
+      {
+        "language_id": "ro",
+        "name": "Romanian"
+      },
+      {
+        "language_id": "ar",
+        "name": "Arabic"
+      },
+      {
+        "language_id": "cs",
+        "name": "Czech"
+      },
+      {
+        "language_id": "el",
+        "name": "Greek"
+      },
+      {
+        "language_id": "fi",
+        "name": "Finnish"
+      },
+      {
+        "language_id": "hr",
+        "name": "Croatian"
+      },
+      {
+        "language_id": "ms",
+        "name": "Malay"
+      },
+      {
+        "language_id": "sk",
+        "name": "Slovak"
+      },
+      {
+        "language_id": "da",
+        "name": "Danish"
+      },
+      {
+        "language_id": "ta",
+        "name": "Tamil"
+      },
+      {
+        "language_id": "uk",
+        "name": "Ukrainian"
+      },
+      {
+        "language_id": "ru",
+        "name": "Russian"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_flash_v2_5",
+    "name": "Eleven Flash v2.5",
+    "description": "Our ultra low latency model in 32 languages. Ideal for conversational use cases.",
+    "can_be_finetuned": true,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      },
+      {
+        "language_id": "ja",
+        "name": "Japanese"
+      },
+      {
+        "language_id": "zh",
+        "name": "Chinese"
+      },
+      {
+        "language_id": "de",
+        "name": "German"
+      },
+      {
+        "language_id": "hi",
+        "name": "Hindi"
+      },
+      {
+        "language_id": "fr",
+        "name": "French"
+      },
+      {
+        "language_id": "ko",
+        "name": "Korean"
+      },
+      {
+        "language_id": "pt",
+        "name": "Portuguese"
+      },
+      {
+        "language_id": "it",
+        "name": "Italian"
+      },
+      {
+        "language_id": "es",
+        "name": "Spanish"
+      },
+      {
+        "language_id": "ru",
+        "name": "Russian"
+      },
+      {
+        "language_id": "id",
+        "name": "Indonesian"
+      },
+      {
+        "language_id": "nl",
+        "name": "Dutch"
+      },
+      {
+        "language_id": "tr",
+        "name": "Turkish"
+      },
+      {
+        "language_id": "fil",
+        "name": "Filipino"
+      },
+      {
+        "language_id": "pl",
+        "name": "Polish"
+      },
+      {
+        "language_id": "sv",
+        "name": "Swedish"
+      },
+      {
+        "language_id": "bg",
+        "name": "Bulgarian"
+      },
+      {
+        "language_id": "ro",
+        "name": "Romanian"
+      },
+      {
+        "language_id": "ar",
+        "name": "Arabic"
+      },
+      {
+        "language_id": "cs",
+        "name": "Czech"
+      },
+      {
+        "language_id": "el",
+        "name": "Greek"
+      },
+      {
+        "language_id": "fi",
+        "name": "Finnish"
+      },
+      {
+        "language_id": "hr",
+        "name": "Croatian"
+      },
+      {
+        "language_id": "ms",
+        "name": "Malay"
+      },
+      {
+        "language_id": "sk",
+        "name": "Slovak"
+      },
+      {
+        "language_id": "da",
+        "name": "Danish"
+      },
+      {
+        "language_id": "ta",
+        "name": "Tamil"
+      },
+      {
+        "language_id": "uk",
+        "name": "Ukrainian"
+      },
+      {
+        "language_id": "hu",
+        "name": "Hungarian"
+      },
+      {
+        "language_id": "no",
+        "name": "Norwegian"
+      },
+      {
+        "language_id": "vi",
+        "name": "Vietnamese"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_turbo_v2_5",
+    "name": "Eleven Turbo v2.5",
+    "description": "Our high quality, low latency model in 32 languages. Best for developer use cases where speed matters and you need non-English languages.",
+    "can_be_finetuned": true,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      },
+      {
+        "language_id": "ja",
+        "name": "Japanese"
+      },
+      {
+        "language_id": "zh",
+        "name": "Chinese"
+      },
+      {
+        "language_id": "de",
+        "name": "German"
+      },
+      {
+        "language_id": "hi",
+        "name": "Hindi"
+      },
+      {
+        "language_id": "fr",
+        "name": "French"
+      },
+      {
+        "language_id": "ko",
+        "name": "Korean"
+      },
+      {
+        "language_id": "pt",
+        "name": "Portuguese"
+      },
+      {
+        "language_id": "it",
+        "name": "Italian"
+      },
+      {
+        "language_id": "es",
+        "name": "Spanish"
+      },
+      {
+        "language_id": "ru",
+        "name": "Russian"
+      },
+      {
+        "language_id": "id",
+        "name": "Indonesian"
+      },
+      {
+        "language_id": "nl",
+        "name": "Dutch"
+      },
+      {
+        "language_id": "tr",
+        "name": "Turkish"
+      },
+      {
+        "language_id": "fil",
+        "name": "Filipino"
+      },
+      {
+        "language_id": "pl",
+        "name": "Polish"
+      },
+      {
+        "language_id": "sv",
+        "name": "Swedish"
+      },
+      {
+        "language_id": "bg",
+        "name": "Bulgarian"
+      },
+      {
+        "language_id": "ro",
+        "name": "Romanian"
+      },
+      {
+        "language_id": "ar",
+        "name": "Arabic"
+      },
+      {
+        "language_id": "cs",
+        "name": "Czech"
+      },
+      {
+        "language_id": "el",
+        "name": "Greek"
+      },
+      {
+        "language_id": "fi",
+        "name": "Finnish"
+      },
+      {
+        "language_id": "hr",
+        "name": "Croatian"
+      },
+      {
+        "language_id": "ms",
+        "name": "Malay"
+      },
+      {
+        "language_id": "sk",
+        "name": "Slovak"
+      },
+      {
+        "language_id": "da",
+        "name": "Danish"
+      },
+      {
+        "language_id": "ta",
+        "name": "Tamil"
+      },
+      {
+        "language_id": "uk",
+        "name": "Ukrainian"
+      },
+      {
+        "language_id": "vi",
+        "name": "Vietnamese"
+      },
+      {
+        "language_id": "no",
+        "name": "Norwegian"
+      },
+      {
+        "language_id": "hu",
+        "name": "Hungarian"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_turbo_v2",
+    "name": "Eleven Turbo v2",
+    "description": "Our English-only, low latency model. Best for developer use cases where speed matters and you only need English. Performance is on par with Turbo v2.5.",
+    "can_be_finetuned": true,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_flash_v2",
+    "name": "Eleven Flash v2",
+    "description": "Our ultra low latency model in english. Ideal for conversational use cases.",
+    "can_be_finetuned": true,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_monolingual_v1",
+    "name": "Eleven English v1",
+    "description": "Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
+    "can_be_finetuned": false,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
+    "model_id": "eleven_multilingual_v1",
+    "name": "Eleven Multilingual v1",
+    "description": "Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
+    "can_be_finetuned": false,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      },
+      {
+        "language_id": "de",
+        "name": "German"
+      },
+      {
+        "language_id": "pl",
+        "name": "Polish"
+      },
+      {
+        "language_id": "es",
+        "name": "Spanish"
+      },
+      {
+        "language_id": "it",
+        "name": "Italian"
+      },
+      {
+        "language_id": "fr",
+        "name": "French"
+      },
+      {
+        "language_id": "pt",
+        "name": "Portuguese"
+      },
+      {
+        "language_id": "hi",
+        "name": "Hindi"
+      },
+      {
+        "language_id": "ar",
+        "name": "Arabic"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  }
+]

--- a/models.json
+++ b/models.json
@@ -742,6 +742,21 @@
     "can_do_voice_conversion": false
   },
   {
+    "model_id": "eleven_monolingual_v1",
+    "name": "Eleven English v1",
+    "description": "Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
+    "can_be_finetuned": false,
+    "token_cost_factor": 1.0,
+    "languages": [
+      {
+        "language_id": "en",
+        "name": "English"
+      }
+    ],
+    "can_do_text_to_speech": true,
+    "can_do_voice_conversion": false
+  },
+  {
     "model_id": "eleven_multilingual_v1",
     "name": "Eleven Multilingual v1",
     "description": "Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
@@ -783,21 +798,6 @@
       {
         "language_id": "ar",
         "name": "Arabic"
-      }
-    ],
-    "can_do_text_to_speech": true,
-    "can_do_voice_conversion": false
-  },
-  {
-    "model_id": "eleven_monolingual_v1",
-    "name": "Eleven English v1",
-    "description": "Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).",
-    "can_be_finetuned": false,
-    "token_cost_factor": 1.0,
-    "languages": [
-      {
-        "language_id": "en",
-        "name": "English"
       }
     ],
     "can_do_text_to_speech": true,

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Offscreen Audio Player</title></head>
+<body>
+<script src="offscreen.js"></script>
+</body>
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,103 @@
+// Offscreen document for audio playback (bypasses page CSP)
+const codec = "audio/mpeg";
+const maxBufferDuration = 90;
+let streamingCompleted = true;
+let mediaSource = null;
+let audioElement = null;
+let sourceBuffer = null;
+let audioQueue = [];
+
+const initAudio = () => {
+  mediaSource = new MediaSource();
+  audioElement = new Audio();
+  audioElement.src = URL.createObjectURL(mediaSource);
+  audioQueue = [];
+  streamingCompleted = false;
+  sourceBuffer = null;
+  
+  // Notify content script when playback ends
+  audioElement.addEventListener("ended", () => {
+    chrome.runtime.sendMessage({ action: "playbackEnded" });
+  });
+};
+
+const processAudioQueue = () => {
+  if (!sourceBuffer || sourceBuffer.updating || audioQueue.length === 0) return;
+  
+  // Remove old buffered data if needed
+  if (sourceBuffer.buffered.length > 0 && 
+      sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0) > maxBufferDuration) {
+    const removeEnd = sourceBuffer.buffered.end(0) - maxBufferDuration;
+    if (removeEnd > sourceBuffer.buffered.start(0)) {
+      sourceBuffer.remove(sourceBuffer.buffered.start(0), removeEnd);
+      return;
+    }
+  }
+  
+  const chunk = audioQueue.shift();
+  try {
+    sourceBuffer.appendBuffer(chunk);
+  } catch (e) {
+    console.error("Error appending buffer:", e);
+  }
+};
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "initAudio") {
+    initAudio();
+    mediaSource.addEventListener("sourceopen", () => {
+      sourceBuffer = mediaSource.addSourceBuffer(codec);
+      sourceBuffer.addEventListener("updateend", processAudioQueue);
+      sendResponse({ success: true });
+    }, { once: true });
+    return true; // async response
+  }
+  
+  if (message.action === "appendAudio") {
+    const chunk = new Uint8Array(message.chunk);
+    audioQueue.push(chunk);
+    processAudioQueue();
+  }
+  
+  if (message.action === "playAudio") {
+    if (audioElement) {
+      audioElement.playbackRate = message.speed || 1;
+      audioElement.play();
+    }
+  }
+  
+  if (message.action === "pauseAudio") {
+    if (audioElement) audioElement.pause();
+  }
+  
+  if (message.action === "stopAudio") {
+    if (audioElement) {
+      audioElement.pause();
+      audioElement.currentTime = 0;
+    }
+  }
+  
+  if (message.action === "streamComplete") {
+    streamingCompleted = true;
+    if (mediaSource && mediaSource.readyState === "open") {
+      // Wait for queue to empty before ending
+      const checkAndEnd = () => {
+        if (audioQueue.length === 0 && sourceBuffer && !sourceBuffer.updating) {
+          mediaSource.endOfStream();
+        } else {
+          setTimeout(checkAndEnd, 100);
+        }
+      };
+      checkAndEnd();
+    }
+  }
+  
+  if (message.action === "getState") {
+    sendResponse({
+      playing: audioElement && !audioElement.paused,
+      currentTime: audioElement ? audioElement.currentTime : 0,
+      duration: audioElement ? audioElement.duration : 0
+    });
+    return true;
+  }
+});

--- a/popup.html
+++ b/popup.html
@@ -29,15 +29,15 @@
         <div class="settingsItemNoPadding">
           <label for="mode">Model:</label>
           <select id="mode">
-            <option value="eleven_v3">Eleven v3 (alpha)</option>
-            <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
-            <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
-            <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
-            <option value="eleven_turbo_v2">Eleven Turbo v2</option>
-            <option value="eleven_flash_v2">Eleven Flash v2</option>
-            <option value="eleven_monolingual_v1">Eleven English v1</option>
-            <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
-          </select>
+  <option value="eleven_v3">Eleven v3 (alpha)</option>
+  <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
+  <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
+  <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
+  <option value="eleven_turbo_v2">Eleven Turbo v2</option>
+  <option value="eleven_flash_v2">Eleven Flash v2</option>
+  <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
+  <option value="eleven_monolingual_v1">Eleven English v1</option>
+</select>
         </div>
         <div class="settingsItemNoPadding">
           <p>

--- a/popup.html
+++ b/popup.html
@@ -24,10 +24,15 @@
       <div class="settingsItemNoPadding">
         <label for="mode">Model:</label>
         <select id="mode">
-          <option value="eleven_turbo_v2">Turbo v2</option>
-          <option value="eleven_turbo_v2_5">Turbo v2.5</option>
-          <option value="eleven_multilingual_v2">Multilingual v2</option>
-        </select>
+  <option value="eleven_v3">Eleven v3 (alpha)</option>
+  <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
+  <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
+  <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
+  <option value="eleven_turbo_v2">Eleven Turbo v2</option>
+  <option value="eleven_flash_v2">Eleven Flash v2</option>
+  <option value="eleven_monolingual_v1">Eleven English v1</option>
+  <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
+</select>
       </div>
       <div class="settingsItemNoPadding">
         <p>

--- a/popup.html
+++ b/popup.html
@@ -12,39 +12,78 @@
       <div class="header">Human Reader</div>
       <div class="header-suffix">
         powered by
-        <a href="https://elevenlabs.io" target="_blank">ElevenLabs</a>
+        <select id="provider">
+          <option value="elevenlabs">ElevenLabs</option>
+          <option value="openai">OpenAI</option>
+        </select>
       </div>
     </div>
     <!-- With valid API key -->
     <div id="settings">
-      <div class="settingsItem">
-        <label for="voices">Voice:</label>
-        <select id="voices"></select>
+      <!-- ElevenLabs settings -->
+      <div id="settingsElevenlabs">
+        <div class="settingsItem">
+          <label for="voices">Voice:</label>
+          <select id="voices"></select>
+        </div>
+        <div class="settingsItemNoPadding">
+          <label for="mode">Model:</label>
+          <select id="mode">
+            <option value="eleven_v3">Eleven v3 (alpha)</option>
+            <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
+            <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
+            <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
+            <option value="eleven_turbo_v2">Eleven Turbo v2</option>
+            <option value="eleven_flash_v2">Eleven Flash v2</option>
+            <option value="eleven_monolingual_v1">Eleven English v1</option>
+            <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
+          </select>
+        </div>
+        <div class="settingsItemNoPadding">
+          <p>
+            Read
+            <a
+              href="https://help.elevenlabs.io/hc/en-us/articles/13313366263441-What-languages-do-you-support"
+              target="_blank"
+              >here</a
+            >
+            for the differences in models and supported languages.
+          </p>
+        </div>
       </div>
-      <div class="settingsItemNoPadding">
-        <label for="mode">Model:</label>
-        <select id="mode">
-  <option value="eleven_v3">Eleven v3 (alpha)</option>
-  <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
-  <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
-  <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
-  <option value="eleven_turbo_v2">Eleven Turbo v2</option>
-  <option value="eleven_flash_v2">Eleven Flash v2</option>
-  <option value="eleven_monolingual_v1">Eleven English v1</option>
-  <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
-</select>
+      <!-- OpenAI settings -->
+      <div id="settingsOpenai" style="display: none;">
+        <div class="settingsItem">
+          <label for="openaiVoice">Voice:</label>
+          <select id="openaiVoice">
+            <option value="alloy">Alloy</option>
+            <option value="ash">Ash</option>
+            <option value="ballad">Ballad</option>
+            <option value="coral">Coral</option>
+            <option value="echo">Echo</option>
+            <option value="fable">Fable</option>
+            <option value="onyx">Onyx</option>
+            <option value="nova">Nova</option>
+            <option value="sage">Sage</option>
+            <option value="shimmer">Shimmer</option>
+            <option value="verse">Verse</option>
+          </select>
+        </div>
+        <div class="settingsItemNoPadding">
+          <label for="openaiModel">Model:</label>
+          <select id="openaiModel">
+            <option value="gpt-4o-mini-tts">GPT-4o Mini TTS</option>
+            <option value="tts-1">TTS-1 (faster)</option>
+            <option value="tts-1-hd">TTS-1 HD (higher quality)</option>
+          </select>
+        </div>
+        <div class="settingsItemNoPadding">
+          <p>
+            See <a href="https://platform.openai.com/docs/guides/text-to-speech" target="_blank">OpenAI TTS docs</a> for voice samples and details.
+          </p>
+        </div>
       </div>
-      <div class="settingsItemNoPadding">
-        <p>
-          Read
-          <a
-            href="https://help.elevenlabs.io/hc/en-us/articles/13313366263441-What-languages-do-you-support"
-            target="_blank"
-            >here</a
-          >
-          for the differences in models and supported languages.
-        </p>
-      </div>
+      <!-- Speed (shared) -->
       <div class="settingsItem">
         <label for="speed">Speed:</label>
         <span id="speedValue">1x</span>
@@ -77,31 +116,58 @@
     <!-- Without valid API key/Setup -->
     <div id="welcome">
       <h3>Welcome</h3>
-      <div>
-        To get started, you need to:
-        <ul>
-          <li>
-            Create an account (or log in) on
-            <a href="https://elevenlabs.io/?from=partnerlove324" target="_blank"
-              >elevenlabs.io</a
-            >
-          </li>
-          <li>
-            Go to your profile page and copy your API key
-            <a
-              href="https://help.elevenlabs.io/hc/en-us/articles/14599447207697-How-to-authorize-yourself-using-your-xi-api-key"
-              target="_blank"
-              >like this</a
-            >
-          </li>
-          <li>Paste the API key into the input field below</li>
-          <li>Click "Set" to get started</li>
-        </ul>
+      <!-- ElevenLabs welcome -->
+      <div id="welcomeElevenlabs">
+        <div>
+          To get started, you need to:
+          <ul>
+            <li>
+              Create an account (or log in) on
+              <a href="https://elevenlabs.io/?from=partnerlove324" target="_blank"
+                >elevenlabs.io</a
+              >
+            </li>
+            <li>
+              Go to your profile page and copy your API key
+              <a
+                href="https://help.elevenlabs.io/hc/en-us/articles/14599447207697-How-to-authorize-yourself-using-your-xi-api-key"
+                target="_blank"
+                >like this</a
+              >
+            </li>
+            <li>Paste the API key into the input field below</li>
+            <li>Click "Set" to get started</li>
+          </ul>
+        </div>
+        <div class="welcomeInput">
+          <label for="apiKey">API Key:</label>
+          <input type="text" id="apiKey" />
+          <button id="setApiKey">Set</button>
+        </div>
       </div>
-      <div class="welcomeInput">
-        <label for="apiKey">API Key:</label>
-        <input type="text" id="apiKey" />
-        <button id="setApiKey">Set</button>
+      <!-- OpenAI welcome -->
+      <div id="welcomeOpenai" style="display: none;">
+        <div>
+          To get started, you need to:
+          <ul>
+            <li>
+              Create an account (or log in) on
+              <a href="https://platform.openai.com" target="_blank"
+                >platform.openai.com</a
+              >
+            </li>
+            <li>
+              Go to <a href="https://platform.openai.com/api-keys" target="_blank">API keys</a> and create a new key
+            </li>
+            <li>Paste the API key into the input field below</li>
+            <li>Click "Set" to get started</li>
+          </ul>
+        </div>
+        <div class="welcomeInput">
+          <label for="openaiApiKey">API Key:</label>
+          <input type="text" id="openaiApiKey" />
+          <button id="setOpenaiApiKey">Set</button>
+        </div>
       </div>
     </div>
 

--- a/popup.html
+++ b/popup.html
@@ -35,8 +35,8 @@
   <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
   <option value="eleven_turbo_v2">Eleven Turbo v2</option>
   <option value="eleven_flash_v2">Eleven Flash v2</option>
-  <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
   <option value="eleven_monolingual_v1">Eleven English v1</option>
+  <option value="eleven_multilingual_v1">Eleven Multilingual v1</option>
 </select>
         </div>
         <div class="settingsItemNoPadding">

--- a/update_extension.py
+++ b/update_extension.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+"""
+ElevenLabs Chrome Extension Updater
+Fetches current models and voices from ElevenLabs API and updates the extension files.
+Run this occasionally to keep your extension up-to-date.
+"""
+
+import json
+import os
+import re
+import requests
+from pathlib import Path
+from getpass import getpass
+
+class ElevenLabsExtensionUpdater:
+    def __init__(self, api_key, extension_path="."):
+        """
+        Initialize the updater.
+        
+        Args:
+            api_key: Your ElevenLabs API key
+            extension_path: Path to the extension directory
+        """
+        self.api_key = api_key
+        self.extension_path = Path(extension_path)
+        self.headers = {
+            "xi-api-key": api_key,
+            "Content-Type": "application/json"
+        }
+        self.base_url = "https://api.elevenlabs.io/v1"
+        
+    def fetch_models(self):
+        """Fetch available models from ElevenLabs API."""
+        print("Fetching available models...")
+        try:
+            response = requests.get(f"{self.base_url}/models", headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+            
+            # Filter for TTS models only
+            tts_models = [
+                model for model in data
+                if model.get("can_do_text_to_speech", False)
+            ]
+            
+            print(f"Found {len(tts_models)} TTS models")
+            return tts_models
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching models: {e}")
+            return []
+    
+    def fetch_voices(self):
+        """Fetch available voices from ElevenLabs API."""
+        print("Fetching available voices...")
+        try:
+            response = requests.get(f"{self.base_url}/voices", headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+            
+            voices = data.get("voices", [])
+            print(f"Found {len(voices)} voices")
+            return voices
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching voices: {e}")
+            return []
+    
+    def get_user_subscription(self):
+        """Get user subscription info to see available features."""
+        print("Fetching subscription info...")
+        try:
+            response = requests.get(f"{self.base_url}/user/subscription", headers=self.headers)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching subscription: {e}")
+            return {}
+    
+    def format_model_for_dropdown(self, model):
+        """Format model data for HTML dropdown."""
+        model_id = model.get("model_id", "")
+        name = model.get("name", model_id)
+        description = model.get("description", "")
+        
+        # Create a readable label
+        label = f"{name}"
+        if description:
+            label = f"{name} - {description[:50]}..."
+        
+        return {
+            "value": model_id,
+            "label": label,
+            "name": name,
+            "description": description
+        }
+    
+    def format_voice_for_dropdown(self, voice):
+        """Format voice data for dropdown."""
+        print(voice)
+        voice_id = voice.get("voice_id", "")
+        name = voice.get("name", voice_id)
+        category = voice.get("category", "unknown")
+        
+        # Add category to label for clarity
+        label = f"{name} ({category})"
+        
+        return {
+            "value": voice_id,
+            "label": label,
+            "name": name,
+            "category": category
+        }
+    
+    def update_popup_html(self, models):
+        """Update popup.html with current models."""
+        popup_file = self.extension_path / "popup.html"
+        
+        if not popup_file.exists():
+            print(f"Error: {popup_file} not found")
+            return False
+        
+        print(f"Updating {popup_file}...")
+        
+        # Read the file
+        with open(popup_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Find the model select dropdown
+        select_pattern = r'(<select id="mode">[\s\S]*?</select>)'
+        match = re.search(select_pattern, content)
+        
+        if not match:
+            print("Error: Could not find model select dropdown in popup.html")
+            return False
+        
+        old_select = match.group(1)
+        
+        # Build new select options
+        options_html = []
+        for model in models:
+            formatted = self.format_model_for_dropdown(model)
+            option = f'  <option value="{formatted["value"]}">{formatted["name"]}</option>'
+            options_html.append(option)
+        
+        new_select = f'<select id="mode">\n' + '\n'.join(options_html) + '\n</select>'
+        
+        # Replace in content
+        content = content.replace(old_select, new_select)
+        
+        # Write back
+        with open(popup_file, 'w', encoding='utf-8') as f:
+            f.write(content)
+        
+        print(f"Updated {popup_file} with {len(models)} models")
+        return True
+    
+    def update_content_js_model_mapping(self, models):
+        """Update the model mapping logic in content.js."""
+        content_file = self.extension_path / "content.js"
+        
+        if not content_file.exists():
+            print(f"Error: {content_file} not found")
+            return False
+        
+        print(f"Updating {content_file}...")
+        
+        # Read the file
+        with open(content_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Find the model mapping section (around line 40-50)
+        # Look for the const model_id = ... pattern
+        pattern = r'(const model_id =\s*[\s\S]*?\n)'
+        match = re.search(pattern, content)
+        
+        if not match:
+            print("Error: Could not find model mapping in content.js")
+            return False
+        
+        # Build new model mapping logic
+        mapping_lines = []
+        mapping_lines.append("  const model_id =")
+        
+        # Add mappings for each model
+        for i, model in enumerate(models):
+            model_id = model.get("model_id", "")
+            model_name = model.get("name", "").lower().replace(" ", "_")
+            
+            # Create condition
+            condition = f"    (mode === \"{model_name}\" || mode === \"{model_id}\") ? \"{model_id}\" :"
+            
+            # For the last model, make it the default
+            if i == len(models) - 1:
+                condition = f"    \"{model_id}\"; // default"
+            
+            mapping_lines.append(condition)
+        
+        new_mapping = '\n'.join(mapping_lines)
+        
+        # Replace in content
+        content = re.sub(pattern, new_mapping + '\n', content)
+        
+        # Write back
+        with open(content_file, 'w', encoding='utf-8') as f:
+            f.write(content)
+        
+        print(f"Updated model mapping in {content_file}")
+        return True
+    
+    def create_models_json(self, models):
+        """Create a JSON file with model information for reference."""
+        models_file = self.extension_path / "models.json"
+        
+        formatted_models = []
+        for model in models:
+            formatted = {
+                "model_id": model.get("model_id"),
+                "name": model.get("name"),
+                "description": model.get("description"),
+                "can_be_finetuned": model.get("can_be_finetuned", False),
+                "token_cost_factor": model.get("token_cost_factor", 1.0),
+                "languages": model.get("languages", []),
+                "can_do_text_to_speech": model.get("can_do_text_to_speech", False),
+                "can_do_voice_conversion": model.get("can_do_voice_conversion", False)
+            }
+            formatted_models.append(formatted)
+        
+        with open(models_file, 'w', encoding='utf-8') as f:
+            json.dump(formatted_models, f, indent=2)
+        
+        print(f"Created {models_file} with model information")
+        return True
+    
+    def create_voices_json(self, voices):
+        """Create a JSON file with voice information for reference."""
+        voices_file = self.extension_path / "voices.json"
+        
+        formatted_voices = []
+        for voice in voices:
+            formatted = {
+                "voice_id": voice.get("voice_id"),
+                "name": voice.get("name"),
+                "category": voice.get("category"),
+                "description": voice.get("description", ""),
+                "labels": voice.get("labels", {}),
+                "preview_url": voice.get("preview_url", ""),
+                "available_for_tiers": voice.get("available_for_tiers", []),
+                "settings": voice.get("settings", {})
+            }
+            formatted_voices.append(formatted)
+        
+        with open(voices_file, 'w', encoding='utf-8') as f:
+            json.dump(formatted_voices, f, indent=2)
+        
+        print(f"Created {voices_file} with voice information")
+        return True
+    
+    def update_manifest_version(self):
+        """Update the manifest.json version (optional)."""
+        manifest_file = self.extension_path / "manifest.json"
+        
+        if not manifest_file.exists():
+            print("Note: manifest.json not found, skipping version update")
+            return False
+        
+        try:
+            with open(manifest_file, 'r', encoding='utf-8') as f:
+                manifest = json.load(f)
+            
+            # Increment version (simple patch version increment)
+            current_version = manifest.get("version", "1.0.0")
+            parts = current_version.split(".")
+            if len(parts) == 3:
+                patch = int(parts[2]) + 1
+                new_version = f"{parts[0]}.{parts[1]}.{patch}"
+                manifest["version"] = new_version
+                
+                with open(manifest_file, 'w', encoding='utf-8') as f:
+                    json.dump(manifest, f, indent=2)
+                
+                print(f"Updated manifest version from {current_version} to {new_version}")
+                return True
+        except Exception as e:
+            print(f"Error updating manifest: {e}")
+        
+        return False
+    
+    def create_update_report(self, models, voices, subscription):
+        """Create a report of what was updated."""
+        import datetime
+        report_file = self.extension_path / "update_report.txt"
+        
+        with open(report_file, 'w', encoding='utf-8') as f:
+            f.write("=== ElevenLabs Extension Update Report ===\n\n")
+            f.write(f"Date: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+            f.write(f"Models found: {len(models)}\n")
+            f.write(f"Voices found: {len(voices)}\n\n")
+            
+            f.write("=== Available Models ===\n")
+            for model in models:
+                f.write(f"- {model.get('name')} ({model.get('model_id')})\n")
+                f.write(f"  Description: {model.get('description', 'N/A')}\n")
+                f.write( "  Languages: " + ', '.join(f"{item['language_id']}: {item['name']}" for item in model.get('languages', [])))
+                f.write(f"  Token cost: {model.get('token_cost_factor', 1.0)}x\n\n")
+            
+            f.write("\n=== Subscription Info ===\n")
+            if subscription:
+                f.write(f"Tier: {subscription.get('tier', 'N/A')}\n")
+                f.write(f"Character limit: {subscription.get('character_limit', 'N/A')}\n")
+                f.write(f"Character count: {subscription.get('character_count', 'N/A')}\n")
+                f.write(f"Can use instant voice cloning: {subscription.get('can_use_instant_voice_cloning', False)}\n")
+                f.write(f"Can use professional voice cloning: {subscription.get('can_use_professional_voice_cloning', False)}\n")
+        
+        print(f"Created update report: {report_file}")
+        return True
+    
+    def run_update(self):
+        """Run the complete update process."""
+        print("=" * 60)
+        print("ElevenLabs Chrome Extension Updater")
+        print("=" * 60)
+        
+        # Fetch data from API
+        models = self.fetch_models()
+        voices = self.fetch_voices()
+        subscription = self.get_user_subscription()
+        
+        if not models:
+            print("No models found. Update aborted.")
+            return False
+        
+        # Update files
+        success = True
+        
+        # Update popup.html with models
+        if not self.update_popup_html(models):
+            success = False
+        
+        # Update content.js model mapping
+        if not self.update_content_js_model_mapping(models):
+            success = False
+        
+        # Create JSON files for reference
+        self.create_models_json(models)
+        self.create_voices_json(voices)
+        
+        # Update manifest version
+        self.update_manifest_version()
+        
+        # Create update report
+        self.create_update_report(models, voices, subscription)
+        
+        if success:
+            print("\n" + "=" * 60)
+            print("UPDATE COMPLETE!")
+            print("=" * 60)
+            print("\nNext steps:")
+            print("1. Load the updated extension in Chrome:")
+            print("   - Go to chrome://extensions/")
+            print("   - Enable 'Developer mode'")
+            print("   - Click 'Load unpacked'")
+            print("   - Select the extension directory")
+            print("\n2. Test the extension with the new models")
+            print("\n3. Check update_report.txt for details")
+        else:
+            print("\nUpdate completed with some errors. Check the output above.")
+        
+        return success
+
+
+def main():
+    """Main function with user interaction."""
+    import sys
+    
+    print("ElevenLabs Chrome Extension Updater")
+    print("-" * 40)
+    
+    # Get API key
+    api_key = getpass("Enter your ElevenLabs API key: ").strip()
+    print(len(api_key), api_key[-4:])
+    if not api_key:
+        print("Error: API key is required")
+        sys.exit(1)
+    
+    # Get extension path
+    default_path = input(f"Enter extension path [default: current directory]: ").strip()
+    extension_path = default_path if default_path else "."
+    
+    # Create updater and run
+    updater = ElevenLabsExtensionUpdater(api_key, extension_path)
+    updater.run_update()
+
+
+if __name__ == "__main__":
+    # You can also run this directly with command line arguments
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Update ElevenLabs Chrome Extension")
+    parser.add_argument("--api-key", help="ElevenLabs API key")
+    parser.add_argument("--path", default=".", help="Extension directory path")
+    parser.add_argument("--auto", action="store_true", help="Run without prompts")
+    
+    args = parser.parse_args()
+    
+    if args.api_key:
+        # Run with command line arguments
+        updater = ElevenLabsExtensionUpdater(args.api_key, args.path)
+        updater.run_update()
+    else:
+        # Run with interactive prompts
+        main()

--- a/update_report.txt
+++ b/update_report.txt
@@ -1,0 +1,46 @@
+=== ElevenLabs Extension Update Report ===
+
+Date: 2026-01-18 08:11:21
+Models found: 8
+Voices found: 20
+
+=== Available Models ===
+- Eleven v3 (alpha) (eleven_v3)
+  Description: The most expressive model. Supports 70+ languages. Requires more prompt engineering than our previous models. In alpha and the reliability will improve over time.
+  Languages: af: Afrikaans, ar: Arabic, hy: Armenian, as: Assamese, az: Azerbaijani, be: Belarusian, bn: Bengali, bs: Bosnian, bg: Bulgarian, ca: Catalan, ceb: Cebuano, ny: Chichewa, hr: Croatian, cs: Czech, da: Danish, nl: Dutch, en: English, et: Estonian, fil: Filipino, fi: Finnish, fr: French, gl: Galician, ka: Georgian, de: German, el: Greek, gu: Gujarati, ha: Hausa, he: Hebrew, hi: Hindi, hu: Hungarian, is: Icelandic, id: Indonesian, ga: Irish, it: Italian, ja: Japanese, jv: Javanese, kn: Kannada, kk: Kazakh, ky: Kirghiz, ko: Korean, lv: Latvian, ln: Lingala, lt: Lithuanian, lb: Luxembourgish, mk: Macedonian, ms: Malay, ml: Malayalam, zh: Mandarin Chinese, mr: Marathi, ne: Nepali, no: Norwegian, ps: Pashto, fa: Persian, pl: Polish, pt: Portuguese, pa: Punjabi, ro: Romanian, ru: Russian, sr: Serbian, sd: Sindhi, sk: Slovak, sl: Slovenian, so: Somali, es: Spanish, sw: Swahili, sv: Swedish, ta: Tamil, te: Telugu, th: Thai, tr: Turkish, uk: Ukrainian, ur: Urdu, vi: Vietnamese, cy: Welsh  Token cost: 1.0x
+
+- Eleven Multilingual v2 (eleven_multilingual_v2)
+  Description: Our most life-like, emotionally rich mode in 29 languages. Best for voice overs, audiobooks, post-production, or any other content creation needs.
+  Languages: en: English, ja: Japanese, zh: Chinese, de: German, hi: Hindi, fr: French, ko: Korean, pt: Portuguese, it: Italian, es: Spanish, id: Indonesian, nl: Dutch, tr: Turkish, fil: Filipino, pl: Polish, sv: Swedish, bg: Bulgarian, ro: Romanian, ar: Arabic, cs: Czech, el: Greek, fi: Finnish, hr: Croatian, ms: Malay, sk: Slovak, da: Danish, ta: Tamil, uk: Ukrainian, ru: Russian  Token cost: 1.0x
+
+- Eleven Flash v2.5 (eleven_flash_v2_5)
+  Description: Our ultra low latency model in 32 languages. Ideal for conversational use cases.
+  Languages: en: English, ja: Japanese, zh: Chinese, de: German, hi: Hindi, fr: French, ko: Korean, pt: Portuguese, it: Italian, es: Spanish, ru: Russian, id: Indonesian, nl: Dutch, tr: Turkish, fil: Filipino, pl: Polish, sv: Swedish, bg: Bulgarian, ro: Romanian, ar: Arabic, cs: Czech, el: Greek, fi: Finnish, hr: Croatian, ms: Malay, sk: Slovak, da: Danish, ta: Tamil, uk: Ukrainian, hu: Hungarian, no: Norwegian, vi: Vietnamese  Token cost: 1.0x
+
+- Eleven Turbo v2.5 (eleven_turbo_v2_5)
+  Description: Our high quality, low latency model in 32 languages. Best for developer use cases where speed matters and you need non-English languages.
+  Languages: en: English, ja: Japanese, zh: Chinese, de: German, hi: Hindi, fr: French, ko: Korean, pt: Portuguese, it: Italian, es: Spanish, ru: Russian, id: Indonesian, nl: Dutch, tr: Turkish, fil: Filipino, pl: Polish, sv: Swedish, bg: Bulgarian, ro: Romanian, ar: Arabic, cs: Czech, el: Greek, fi: Finnish, hr: Croatian, ms: Malay, sk: Slovak, da: Danish, ta: Tamil, uk: Ukrainian, vi: Vietnamese, no: Norwegian, hu: Hungarian  Token cost: 1.0x
+
+- Eleven Turbo v2 (eleven_turbo_v2)
+  Description: Our English-only, low latency model. Best for developer use cases where speed matters and you only need English. Performance is on par with Turbo v2.5.
+  Languages: en: English  Token cost: 1.0x
+
+- Eleven Flash v2 (eleven_flash_v2)
+  Description: Our ultra low latency model in english. Ideal for conversational use cases.
+  Languages: en: English  Token cost: 1.0x
+
+- Eleven English v1 (eleven_monolingual_v1)
+  Description: Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
+  Languages: en: English  Token cost: 1.0x
+
+- Eleven Multilingual v1 (eleven_multilingual_v1)
+  Description: Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
+  Languages: en: English, de: German, pl: Polish, es: Spanish, it: Italian, fr: French, pt: Portuguese, hi: Hindi, ar: Arabic  Token cost: 1.0x
+
+
+=== Subscription Info ===
+Tier: free
+Character limit: 10000
+Character count: 0
+Can use instant voice cloning: False
+Can use professional voice cloning: False

--- a/update_report.txt
+++ b/update_report.txt
@@ -1,6 +1,6 @@
 === ElevenLabs Extension Update Report ===
 
-Date: 2026-01-18 08:11:21
+Date: 2026-01-19 20:05:45
 Models found: 8
 Voices found: 20
 
@@ -29,18 +29,18 @@ Voices found: 20
   Description: Our ultra low latency model in english. Ideal for conversational use cases.
   Languages: en: English  Token cost: 1.0x
 
-- Eleven English v1 (eleven_monolingual_v1)
-  Description: Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
-  Languages: en: English  Token cost: 1.0x
-
 - Eleven Multilingual v1 (eleven_multilingual_v1)
   Description: Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
   Languages: en: English, de: German, pl: Polish, es: Spanish, it: Italian, fr: French, pt: Portuguese, hi: Hindi, ar: Arabic  Token cost: 1.0x
+
+- Eleven English v1 (eleven_monolingual_v1)
+  Description: Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
+  Languages: en: English  Token cost: 1.0x
 
 
 === Subscription Info ===
 Tier: free
 Character limit: 10000
-Character count: 0
+Character count: 300
 Can use instant voice cloning: False
 Can use professional voice cloning: False

--- a/update_report.txt
+++ b/update_report.txt
@@ -1,6 +1,6 @@
 === ElevenLabs Extension Update Report ===
 
-Date: 2026-01-19 20:05:45
+Date: 2026-01-20 06:13:45
 Models found: 8
 Voices found: 20
 
@@ -29,18 +29,18 @@ Voices found: 20
   Description: Our ultra low latency model in english. Ideal for conversational use cases.
   Languages: en: English  Token cost: 1.0x
 
-- Eleven Multilingual v1 (eleven_multilingual_v1)
-  Description: Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
-  Languages: en: English, de: German, pl: Polish, es: Spanish, it: Italian, fr: French, pt: Portuguese, hi: Hindi, ar: Arabic  Token cost: 1.0x
-
 - Eleven English v1 (eleven_monolingual_v1)
   Description: Our first ever text to speech model. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
   Languages: en: English  Token cost: 1.0x
+
+- Eleven Multilingual v1 (eleven_multilingual_v1)
+  Description: Our first Multilingual model, capability of generating speech in 10 languages. Now outclassed by Multilingual v2 (for content creation) and Turbo v2.5 (for low latency use cases).
+  Languages: en: English, de: German, pl: Polish, es: Spanish, it: Italian, fr: French, pt: Portuguese, hi: Hindi, ar: Arabic  Token cost: 1.0x
 
 
 === Subscription Info ===
 Tier: free
 Character limit: 10000
-Character count: 300
+Character count: 333
 Can use instant voice cloning: False
 Can use professional voice cloning: False

--- a/voices.json
+++ b/voices.json
@@ -1,0 +1,340 @@
+[
+  {
+    "voice_id": "CwhRBWXzGAHq8TQ4Fs17",
+    "name": "Roger - Laid-Back, Casual, Resonant",
+    "category": "premade",
+    "description": "Easy going and perfect for casual conversations.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "classy",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/CwhRBWXzGAHq8TQ4Fs17/58ee3ff5-f6f2-4628-93b8-e38eb31806b0.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "EXAVITQu4vr4xnSDxMaL",
+    "name": "Sarah - Mature, Reassuring, Confident",
+    "category": "premade",
+    "description": "Young adult woman with a confident and warm, mature quality and a reassuring, professional tone.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "professional",
+      "age": "young",
+      "gender": "female",
+      "language": "en",
+      "use_case": "entertainment_tv"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/EXAVITQu4vr4xnSDxMaL/01a3e33c-6e99-4ee7-8543-ff2216a32186.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "FGY2WhTYpPnrIDTdsKH5",
+    "name": "Laura - Enthusiast, Quirky Attitude",
+    "category": "premade",
+    "description": "This young adult female voice delivers sunny enthusiasm with a quirky attitude.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "sassy",
+      "age": "young",
+      "gender": "female",
+      "language": "en",
+      "use_case": "social_media"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/FGY2WhTYpPnrIDTdsKH5/67341759-ad08-41a5-be6e-de12fe448618.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "IKne3meq5aSn9XLyUdCD",
+    "name": "Charlie - Deep, Confident, Energetic",
+    "category": "premade",
+    "description": "A young Australian male with a confident and energetic voice.",
+    "labels": {
+      "accent": "australian",
+      "descriptive": "hyped",
+      "age": "young",
+      "gender": "male",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/IKne3meq5aSn9XLyUdCD/102de6f2-22ed-43e0-a1f1-111fa75c5481.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "JBFqnCBsd6RMkjVDRZzb",
+    "name": "George - Warm, Captivating Storyteller",
+    "category": "premade",
+    "description": "Warm resonance that instantly captivates listeners.",
+    "labels": {
+      "accent": "british",
+      "descriptive": "mature",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "narrative_story"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/JBFqnCBsd6RMkjVDRZzb/e6206d1a-0721-4787-aafb-06a6e705cac5.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "N2lVS1w4EtoT3dr4eOWO",
+    "name": "Callum - Husky Trickster",
+    "category": "premade",
+    "description": "Deceptively gravelly, yet unsettling edge.",
+    "labels": {
+      "accent": "american",
+      "age": "middle_aged",
+      "language": "en",
+      "gender": "male",
+      "use_case": "characters_animation"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/N2lVS1w4EtoT3dr4eOWO/ac833bd8-ffda-4938-9ebc-b0f99ca25481.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "SAz9YHcvj6GT2YYXdXww",
+    "name": "River - Relaxed, Neutral, Informative",
+    "category": "premade",
+    "description": "A relaxed, neutral voice ready for narrations or conversational projects.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "calm",
+      "age": "middle_aged",
+      "gender": "neutral",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/SAz9YHcvj6GT2YYXdXww/e6c95f0b-2227-491a-b3d7-2249240decb7.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "SOYHLrjzK2X1ezoPC6cr",
+    "name": "Harry - Fierce Warrior",
+    "category": "premade",
+    "description": "An animated warrior ready to charge forward.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "rough",
+      "age": "young",
+      "gender": "male",
+      "language": "en",
+      "use_case": "characters_animation"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/SOYHLrjzK2X1ezoPC6cr/86d178f6-f4b6-4e0e-85be-3de19f490794.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "TX3LPaxmHKxFdv7VOQHJ",
+    "name": "Liam - Energetic, Social Media Creator",
+    "category": "premade",
+    "description": "A young adult with energy and warmth - suitable for reels and shorts.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "confident",
+      "age": "young",
+      "gender": "male",
+      "language": "en",
+      "use_case": "social_media"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/TX3LPaxmHKxFdv7VOQHJ/63148076-6363-42db-aea8-31424308b92c.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "Xb7hH8MSUJpSbSDYk0k2",
+    "name": "Alice - Clear, Engaging Educator",
+    "category": "premade",
+    "description": "Clear and engaging, friendly woman with a British accent suitable for e-learning.",
+    "labels": {
+      "accent": "british",
+      "descriptive": "professional",
+      "age": "middle_aged",
+      "gender": "female",
+      "language": "en",
+      "use_case": "informative_educational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/Xb7hH8MSUJpSbSDYk0k2/d10f7534-11f6-41fe-a012-2de1e482d336.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "XrExE9yKIg1WjnnlVkGX",
+    "name": "Matilda - Knowledgable, Professional",
+    "category": "premade",
+    "description": "A professional woman with a pleasing alto pitch. Suitable for many use cases.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "upbeat",
+      "age": "middle_aged",
+      "gender": "female",
+      "language": "en",
+      "use_case": "informative_educational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/XrExE9yKIg1WjnnlVkGX/b930e18d-6b4d-466e-bab2-0ae97c6d8535.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "bIHbv24MWmeRgasZH58o",
+    "name": "Will - Relaxed Optimist",
+    "category": "premade",
+    "description": "Conversational and laid back.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "chill",
+      "age": "young",
+      "gender": "male",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/bIHbv24MWmeRgasZH58o/8caf8f3d-ad29-4980-af41-53f20c72d7a4.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "cgSgspJ2msm6clMCkdW9",
+    "name": "Jessica - Playful, Bright, Warm",
+    "category": "premade",
+    "description": "Young and popular, this playful American female voice is perfect for trendy content.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "cute",
+      "age": "young",
+      "gender": "female",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/cgSgspJ2msm6clMCkdW9/56a97bf8-b69b-448f-846c-c3a11683d45a.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "cjVigY5qzO86Huf0OWal",
+    "name": "Eric - Smooth, Trustworthy",
+    "category": "premade",
+    "description": "A smooth tenor pitch from a man in his 40s - perfect for agentic use cases.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "classy",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/cjVigY5qzO86Huf0OWal/d098fda0-6456-4030-b3d8-63aa048c9070.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "iP95p4xoKVk53GoZ742B",
+    "name": "Chris - Charming, Down-to-Earth",
+    "category": "premade",
+    "description": "Natural and real, this down-to-earth voice is great across many use-cases.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "casual",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "conversational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/iP95p4xoKVk53GoZ742B/3f4bde72-cc48-40dd-829f-57fbf906f4d7.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "nPczCjzI2devNBz1zQrb",
+    "name": "Brian - Deep, Resonant and Comforting",
+    "category": "premade",
+    "description": "Middle-aged man with a resonant and comforting tone. Great for narrations and advertisements.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "classy",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "social_media"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/nPczCjzI2devNBz1zQrb/2dd3e72c-4fd3-42f1-93ea-abc5d4e5aa1d.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "onwK4e9ZLuTAKqWW03F9",
+    "name": "Daniel - Steady Broadcaster",
+    "category": "premade",
+    "description": "A strong voice perfect for delivering a professional broadcast or news story.",
+    "labels": {
+      "accent": "british",
+      "descriptive": "formal",
+      "age": "middle_aged",
+      "gender": "male",
+      "language": "en",
+      "use_case": "informative_educational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/onwK4e9ZLuTAKqWW03F9/7eee0236-1a72-4b86-b303-5dcadc007ba9.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "pFZP5JQG7iQjIQuC4Bku",
+    "name": "Lily - Velvety Actress",
+    "category": "premade",
+    "description": "Velvety British female voice delivers news and narrations with warmth and clarity.",
+    "labels": {
+      "accent": "british",
+      "descriptive": "confident",
+      "age": "middle_aged",
+      "gender": "female",
+      "language": "en",
+      "use_case": "informative_educational"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/pFZP5JQG7iQjIQuC4Bku/89b68b35-b3dd-4348-a84a-a3c13a3c2b30.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "pNInz6obpgDQGcFmaJgB",
+    "name": "Adam - Dominant, Firm",
+    "category": "premade",
+    "description": "A bright tenor pitch that immediately cuts through. The delivery is brash and openly confident, speaking with unwavering certainty and a slightly aggressive self-assurance.",
+    "labels": {
+      "accent": "american",
+      "age": "middle_aged",
+      "language": "en",
+      "gender": "male",
+      "use_case": "social_media"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/pNInz6obpgDQGcFmaJgB/d6905d7a-dd26-4187-bfff-1bd3a5ea7cac.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  },
+  {
+    "voice_id": "pqHfZKP75CvOlQylNhV4",
+    "name": "Bill - Wise, Mature, Balanced",
+    "category": "premade",
+    "description": "Friendly and comforting voice ready to narrate your stories.",
+    "labels": {
+      "accent": "american",
+      "descriptive": "crisp",
+      "age": "old",
+      "gender": "male",
+      "language": "en",
+      "use_case": "advertisement"
+    },
+    "preview_url": "https://storage.googleapis.com/eleven-public-prod/premade/voices/pqHfZKP75CvOlQylNhV4/d782b3ff-84ba-4029-848c-acf01285524d.mp3",
+    "available_for_tiers": [],
+    "settings": null
+  }
+]


### PR DESCRIPTION
## Description

This PR adds support for OpenAI's TTS API (including GPT-4o-mini-TTS) as an alternative to ElevenLabs, and fixes issues with Manifest V3 compatibility.

### Features
- **OpenAI TTS support**: Users can now choose between ElevenLabs and OpenAI as their TTS provider
  - Supports models: `gpt-4o-mini-tts`, `tts-1`, `tts-1-hd`
  - Supports voices: alloy, ash, ballad, coral, echo, fable, onyx, nova, sage, shimmer, verse
- **Provider selector** in popup UI to switch between ElevenLabs and OpenAI

### Fixes
- **CSP compatibility**: Audio playback now uses an offscreen document, fixing playback on sites with strict CSP (e.g. GitHub)
- **Manifest V3 fixes**:
  - Removed deprecated `background.persistent` property
  - Wrapped `contextMenus.create` in `onInstalled` listener to prevent duplicate ID errors
  - Removed unnecessary `return true` from message listener

### Files Changed
- `manifest.json` - Added `offscreen` permission, OpenAI host permission, removed V2 properties
- `popup.html` / `popup.js` - Provider selector UI, OpenAI settings
- `content.js` - Refactored to support both providers, uses offscreen for audio
- `background.js` - Offscreen document management, fixed async issues
- `offscreen.html` / `offscreen.js` - New files for CSP-safe audio playback

### Developer Tooling
- **`update_extension.py`**: Python script to fetch and update ElevenLabs models and voices from their API
  - Keeps `voices.json`, `models.json`, and popup model dropdown in sync with ElevenLabs' latest offerings
  - Can be run interactively or via command line with `--api-key` and `--path` arguments
  - Useful for maintainers to periodically refresh available voices/models without manual editing
